### PR TITLE
Pinning GitHub actions

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -18,7 +18,7 @@ permissions:
     - cron: 0 0 * * 0
 jobs:
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@3fdab59e74dda7831d7401f7aa1bb55d706913d7 # v15
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -13,7 +13,7 @@ permissions:
       - '*/RELEASES.md'
 jobs:
   publish:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@3fdab59e74dda7831d7401f7aa1bb55d706913d7 # v15
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       packagist_token: ${{ secrets.PACKAGIST_TOKEN }}

--- a/.github/workflows/tagging.yaml
+++ b/.github/workflows/tagging.yaml
@@ -12,7 +12,7 @@ permissions:
     workflow_dispatch: {}
 jobs:
     tag:
-        uses: speakeasy-api/sdk-generation-action/.github/workflows/tag.yaml@v15
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/tag.yaml@3fdab59e74dda7831d7401f7aa1bb55d706913d7 # v15
         with:
             registry_tags: main
         secrets:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pins our GitHub reusable workflows to a specific commit (3fdab59… for v15) to enforce version locking and comply with the org-wide policy in ENG-11298. Updated sdk_generation.yaml, sdk_publish.yaml, and tagging.yaml to use the pinned SHA.

<sup>Written for commit 47aaee7265156a0b18c2e740c3d95889b1b9599e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

